### PR TITLE
Attempt to use common trait between variants

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,7 +40,7 @@ checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "apt-sources"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "deb822-lossless",
  "indoc",

--- a/apt-sources/Cargo.toml
+++ b/apt-sources/Cargo.toml
@@ -2,7 +2,7 @@
 name = "apt-sources"
 authors = ["Michał Fita <4925040+michalfita@users.noreply.github.com>"]
 edition = "2021"
-version = "0.1.0"
+version = "0.1.1"
 license = "Apache-2.0"
 description = "A parser for APT source files (package repositories specification)"
 repository = { workspace = true }
@@ -13,6 +13,10 @@ categories = ["parser-implementations"]
 [dependencies]
 deb822-lossless = { version = ">=0.2", path = "..", features = ["derive"] }
 url = { version = "2.5.4", features = ["serde"] }
+
+[features]
+default = ["lossless"]
+lossless = []
 
 [dev-dependencies]
 indoc = { version = "2.0.5" }

--- a/apt-sources/examples/source-for-docker.rs
+++ b/apt-sources/examples/source-for-docker.rs
@@ -1,4 +1,4 @@
-use apt_sources::Repositories;
+use apt_sources::{Repositories, traits::Repository as RepositoryTrait};
 use indoc::indoc;
 
 pub const TEXT: &str = indoc! {r#"

--- a/apt-sources/src/error.rs
+++ b/apt-sources/src/error.rs
@@ -20,12 +20,20 @@ pub enum RepositoryError {
     /// Errors in lossless parser
     Lossless(deb822_lossless::lossless::Error),
     /// I/O Error
-    Io(std::io::Error)
+    Io(std::io::Error),
+    /// Problem with URL validity
+    URLParsingFailure(url::ParseError)
 }
 
 impl From<std::io::Error> for RepositoryError {
     fn from(e: std::io::Error) -> Self {
         Self::Io(e)
+    }
+}
+
+impl From<url::ParseError> for RepositoryError {
+    fn from(e: url::ParseError) -> Self {
+        Self::URLParsingFailure(e)
     }
 }
 
@@ -40,6 +48,7 @@ impl std::fmt::Display for RepositoryError {
             Self::Lossy(e) => write!(f, "Lossy parser error: {}", e),
             Self::Lossless(e) => write!(f, "Lossless parser error: {}", e),
             Self::Io(e) => write!(f, "IO error: {}", e),
+            Self::URLParsingFailure(e) => write!(f, "URL parsing failure: {}", e),
         }
     }
 }

--- a/apt-sources/src/lossless.rs
+++ b/apt-sources/src/lossless.rs
@@ -1,0 +1,294 @@
+//! This optional module adds feature of lossless handling of the APT repositories,
+//! meaning changes retain structure and unprocessed data of sources, like comments.
+//! 
+//! Use either lossy or lossless as you see fit, both serve the same purpose, but
+//! with different trade-offs.
+//! 
+//! # Examples
+//! ```rust
+//! use apt_sources::{lossless::Repositories, traits::Repository};
+//! use std::path::Path;
+//!
+//! let text = r#"# Example repository sources for APT
+//! Types: deb
+//! URIs: http://ports.ubuntu.com/
+//! Suites: noble
+//! Components: stable
+//! Architectures: arm64
+//! Signed-By:
+//!  -----BEGIN PGP PUBLIC KEY BLOCK-----
+//!  .
+//!  mDMEY865UxYJKwYBBAHaRw8BAQdAd7Z0srwuhlB6JKFkcf4HU4SSS/xcRfwEQWzr
+//!  crf6AEq0SURlYmlhbiBTdGFibGUgUmVsZWFzZSBLZXkgKDEyL2Jvb2t3b3JtKSA8
+//!  ZGViaWFuLXJlbGVhc2VAbGlzdHMuZGViaWFuLm9yZz6IlgQTFggAPhYhBE1k/sEZ
+//!  wgKQZ9bnkfjSWFuHg9SBBQJjzrlTAhsDBQkPCZwABQsJCAcCBhUKCQgLAgQWAgMB
+//!  Ah4BAheAAAoJEPjSWFuHg9SBSgwBAP9qpeO5z1s5m4D4z3TcqDo1wez6DNya27QW
+//!  WoG/4oBsAQCEN8Z00DXagPHbwrvsY2t9BCsT+PgnSn9biobwX7bDDg==
+//!  =5NZE
+//!  -----END PGP PUBLIC KEY BLOCK-----"#;
+//!
+//! let r = text.parse::<Repositories>().unwrap();
+//! let r = r.repositories().nth(0).unwrap();
+//! let suites = r.suites();
+//! assert_eq!(suites[0], "noble");
+//! ```
+
+use std::{borrow::{Borrow, Cow}, collections::HashSet, ops::Index, slice::SliceIndex, str::FromStr};
+
+use deb822_lossless::{Deb822, Paragraph};
+use url::Url;
+
+use crate::{error::RepositoryError, signature::Signature, traits, RepositoryType};
+
+/// A structure representing APT repository as declared by DEB822 source file,
+/// this is slower lossless variant (retaining unsupported fields and comments).
+#[derive(PartialEq)]
+pub struct Repository(Paragraph);
+
+impl Repository {
+    fn return_string_array_cow(&self, key: &str) -> Cow<'_, [String]> {
+        Cow::Owned(self.0.get(key)
+            .unwrap() // TODO: type is mandatory, but this is lazy evaluation, that normally would fail deserialization
+            .split_whitespace()
+            .map(|s| s.to_owned())
+            .collect())
+    }
+
+    fn return_optional_yes_no(&self, key: &str) -> Option<bool> {
+        self.0.get(key).map_or(None,|v| super::deserialize_yesno(&v).ok()) // TODO: error consumed!
+    }
+}
+
+impl traits::Repository for Repository {
+    fn enabled(&self) -> bool {
+        self.0.get("Enabled").is_none_or(|x| x == "yes")
+    }
+
+    fn types(&self) -> std::collections::HashSet<crate::RepositoryType> {
+        self.0.get("Types")
+            .unwrap() // TODO: type is mandatory, be this is lazy evaluation, that normally would fail deserialization
+            .split_whitespace()
+            .map(|t| RepositoryType::from_str(t))
+            .collect::<Result<HashSet<RepositoryType>, RepositoryError>>()
+            .unwrap() // TODO: incorrect values would normally fail deserialization
+    }
+
+    fn uris(&self) -> Cow<'_, [url::Url]> {
+        Cow::Owned(self.0.get("URIs")
+            .unwrap() // TODO: type is mandatory, but this is lazy evaluation, that normally would fail deserialization
+            .split_whitespace()
+            .map(|u| Url::from_str(u))
+            .collect::<Result<Vec<Url>, url::ParseError>>()
+            .unwrap())
+    }
+
+    fn suites(&self) -> Cow<'_, [String]> {
+        self.return_string_array_cow("Suites")
+    }
+
+    fn components(&self) -> Cow<'_, [String]> {
+        self.return_string_array_cow("Components")
+    }
+
+    fn architectures(&self) -> Cow<'_, [String]> {
+        self.return_string_array_cow("Architectures")
+    }
+
+    fn languages(&self) -> Cow<'_, [String]> {
+        self.return_string_array_cow("Languages")
+    }
+
+    fn targets(&self) ->  Cow<'_, [String]> {
+        self.return_string_array_cow("Targets")
+    }
+
+    fn pdiffs(&self) -> Option<bool> {
+        self.return_optional_yes_no("PDiffs")
+    }
+
+    fn by_hash(&self) -> Option<crate::YesNoForce> {
+        self.0.get("By-Hash").map_or(None, |v| super::YesNoForce::from_str(&v).ok()) // TODO: error consumed! (quitely ignored if values don't match)
+    }
+
+    fn allow_insecure(&self) -> Option<bool> {
+        self.return_optional_yes_no("Allow-Insecure")
+    }
+
+    fn allow_weak(&self) -> Option<bool> {
+        self.return_optional_yes_no("Allow-Weak")
+    }
+
+    fn allow_downgrade_to_insecure(&self) -> Option<bool> {
+        self.return_optional_yes_no("Allow-Downgrade-To-Insecure")
+    }
+
+    fn trusted(&self) -> Option<bool> {
+        self.return_optional_yes_no("Trusted")
+    }
+
+    fn signature(&self) -> Option<Cow<'_, crate::signature::Signature>> {
+        self.0.get("Signed-By")
+            .and_then(|v| Signature::from_str(&v).ok()) // TODO: another case of errors in late parsing
+            .and_then(|s| Some(Cow::Owned(s)))
+        
+        //filter(|v| Signature::from_str(&v).ok().and_then(|s| Cow::Owned(s))) 
+    }
+
+    fn x_repolib_name(&self) -> Option<Cow<'_, str>> {
+        self.0.get("X-Repolib-Name").map(|x| Cow::Owned(x))
+    }
+
+    fn description(&self) -> Option<Cow<'_, str>> {
+        self.0.get("Description").map(|x| Cow::Owned(x))
+    }
+}
+
+
+/// Container for multiple `Repository` specifications as single `.sources` file may contain as per specification
+#[derive(Debug)]
+pub struct Repositories(Deb822);
+
+impl Repositories {
+    /// Provides iterator over individual repositories in the whole file
+    pub fn repositories(&self) -> impl Iterator<Item = Repository> { // TODO: repository is _a copy_ of the paragraph! not compatible with lossy
+        self.0.paragraphs().filter_map(|p| Some(Repository(p)))
+    }
+}
+
+impl std::str::FromStr for Repositories {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let deb822: deb822_lossless::Deb822 = s
+            .parse()
+            .map_err(|e: deb822_lossless::ParseError| e.to_string())?;
+
+        //let repos = deb822.paragraphs().map(|p| Repository::from_paragraph(&p)).collect::<Result<Vec<Repository>, Self::Err>>()?;
+        Ok(Repositories(deb822))
+    }
+}
+
+// TODO: this cannot be easily implemented to act like in `Vec<>` as we don't have slices of `Paragraph`s mapped into `Repository`s
+// impl<Idx> Index<Idx> for Repositories 
+// where 
+//     Idx: SliceIndex<[Repository], Output = Repository>
+// {
+//     type Output = Idx::Output;
+
+//     #[inline(always)]
+//     fn index(&self, index: Idx) -> &Self::Output {
+//         self.0.paragraphs().nth(index).expect("Index out of bounds").into()
+//     }
+// }
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use indoc::indoc;
+
+    use crate::{signature::Signature, RepositoryType};
+    use crate::traits::Repository as RepositoryTrait;
+
+    use super::{Repositories, Repository};
+
+    #[test]
+    fn test_not_machine_readable() {
+        let s = indoc!(r#"
+            deb [arch=arm64 signed-by=/usr/share/keyrings/docker.gpg] http://ports.ubuntu.com/ noble stable
+        "#);
+        let ret = s.parse::<Repositories>();
+        assert!(ret.is_err());
+        //assert_eq!(ret.unwrap_err(), "Not machine readable".to_string());
+        assert_eq!(ret.unwrap_err(), "expected ':', got Some(NEWLINE)\n".to_owned());
+    }
+
+    #[test]
+    fn test_parse_trivial() {
+        let s = indoc!(r#"
+            Types: deb
+            URIs: https://ports.ubuntu.com/
+            Suites: jammy
+            Components: main restricted universe multiverse
+        "#);
+
+        let repos = s.parse::<Repositories>().expect("Shall be parsed flawlessly");
+        let only_repo = repos.repositories().next().expect("Failed to pick only repo"); 
+        assert!(only_repo.types().contains(&super::RepositoryType::Binary));
+        assert_eq!(only_repo.components().as_ref(), ["main".to_owned(), "restricted".to_owned(), "universe".to_owned(), "multiverse".to_owned()]);
+    }
+
+    #[test]
+    fn test_parse_w_keyblock() {
+        let s = indoc!(r#"
+            Types: deb
+            URIs: http://ports.ubuntu.com/
+            Suites: noble
+            Components: stable
+            Architectures: arm64
+            Signed-By:
+             -----BEGIN PGP PUBLIC KEY BLOCK-----
+             .
+             mDMEY865UxYJKwYBBAHaRw8BAQdAd7Z0srwuhlB6JKFkcf4HU4SSS/xcRfwEQWzr
+             crf6AEq0SURlYmlhbiBTdGFibGUgUmVsZWFzZSBLZXkgKDEyL2Jvb2t3b3JtKSA8
+             ZGViaWFuLXJlbGVhc2VAbGlzdHMuZGViaWFuLm9yZz6IlgQTFggAPhYhBE1k/sEZ
+             wgKQZ9bnkfjSWFuHg9SBBQJjzrlTAhsDBQkPCZwABQsJCAcCBhUKCQgLAgQWAgMB
+             Ah4BAheAAAoJEPjSWFuHg9SBSgwBAP9qpeO5z1s5m4D4z3TcqDo1wez6DNya27QW
+             WoG/4oBsAQCEN8Z00DXagPHbwrvsY2t9BCsT+PgnSn9biobwX7bDDg==
+             =5NZE
+             -----END PGP PUBLIC KEY BLOCK-----
+        "#);
+
+        let repos = s.parse::<Repositories>().expect("Shall be parsed flawlessly");
+        let only_repo = repos.repositories().nth(0).expect("Failed to pick only repo");
+        assert!(only_repo.types().contains(&super::RepositoryType::Binary));
+        assert!(matches!(only_repo.signature().expect("Failed to get Signature"), Cow::Owned(Signature::KeyBlock(_))));
+    }
+
+    #[test]
+    fn test_parse_w_keypath() {
+        let s = indoc!(r#"
+            Types: deb
+            URIs: http://ports.ubuntu.com/
+            Suites: noble
+            Components: stable
+            Architectures: arm64
+            Signed-By: /usr/share/keyrings/ubuntu-archive-keyring.gpg
+        "#);
+
+        let repos = s.parse::<Repositories>().expect("Shall be parsed flawlessly");
+        let only_repo = repos.repositories().nth(0).expect("Failed to pick only repo"); 
+        assert!(only_repo.types().contains(&super::RepositoryType::Binary));
+        assert!(matches!(only_repo.signature().expect("Failed to get Signature").as_ref(), Signature::KeyPath(_)));
+    }
+
+    // #[test]
+    // fn test_serialize() {
+    //     //let repos = Repositories::empty();
+    //     let repos = Repositories::new([
+    //         Repository {
+    //             enabled: Some(true), // TODO: looks odd, as only `Enabled: no` in meaningful
+    //             types: HashSet::from([RepositoryType::Binary]),
+    //             architectures: Some(vec!["arm64".to_owned()]),
+    //             uris: vec![Url::from_str("https://deb.debian.org/debian").unwrap()],
+    //             suites: vec!["jammy".to_owned()],
+    //             components: vec!["main". to_owned()],
+    //             signature: None,
+    //             x_repolib_name: None,
+    //             languages: None,
+    //             targets: None,
+    //             pdiffs: None,
+    //             ..Default::default()
+    //         }
+    //     ]);
+    //     let text = repos.to_string();
+    //     assert_eq!(text, indoc! {r#"
+    //         Enabled: yes
+    //         Types: deb
+    //         URIs: https://deb.debian.org/debian
+    //         Suites: jammy
+    //         Components: main
+    //         Architectures: arm64
+    //     "#});
+    // }
+}

--- a/apt-sources/src/traits.rs
+++ b/apt-sources/src/traits.rs
@@ -1,0 +1,62 @@
+//! Module holds traits for dealing with two kinds of repository sources representation in convenient polymorphic way
+use std::{borrow::Cow, collections::HashSet};
+
+use url::Url;
+
+use crate::{signature::Signature, RepositoryType, YesNoForce};
+
+/// This trait commonize immutable access to both lossy and lossless representation of a APT's source repository
+pub trait Repository {
+    /// Whether the repository source is active and taken into account by APT
+    fn enabled(&self) -> bool;
+
+    /// The value `RepositoryType ->  -> Binary` (`deb`) or/and `RepositoryType ->  -> Source` (`deb-src`)
+    fn types(&self) -> HashSet<RepositoryType>;
+
+    /// The address(es) of the repository
+    fn uris(&self) -> Cow<'_, [Url]>;
+
+    /// The distribution name as codename or suite type (like `stable` or `testing`)
+    fn suites(&self) -> Cow<'_, [String]>;
+
+    /// Section of the repository, usually `main`, `contrib` or `non-free`
+    fn components(&self) -> Cow<'_, [String]>;
+
+    /// (Optional) Architectures binaries from this repository run on
+    fn architectures(&self) -> Cow<'_, [String]>;
+    
+    /// (Optional) Translations support to download
+    fn languages(&self) -> Cow<'_, [String]>;
+
+    /// (Optional) Download targets to acquire from this source
+    fn targets(&self) ->  Cow<'_, [String]>;
+    
+    /// (Optional) Controls if APT should try PDiffs instead of downloading indexes entirely; if not set defaults to configuration option `Acquire ->  -> PDiffs`
+    fn pdiffs(&self) -> Option<bool>;
+
+    /// (Optional) Controls if APT should try to acquire indexes via a URI constructed from a hashsum of the expected file
+    fn by_hash(&self) -> Option<YesNoForce>;
+
+    /// (Optional) If yes circumvents parts of `apt-secure`, don't thread lightly
+    fn allow_insecure(&self) -> Option<bool>;
+
+    /// (Optional) If yes circumvents parts of `apt-secure`, don't thread lightly
+    fn allow_weak(&self) -> Option<bool>;
+
+    /// (Optional) If yes circumvents parts of `apt-secure`, don't thread lightly
+    fn allow_downgrade_to_insecure(&self) -> Option<bool>; // TODO: redundant option, not present = default no
+
+    /// (Optional) If set forces whether APT considers source as rusted or no (default not present is a third state)
+    fn trusted(&self) -> Option<bool>;
+
+    /// (Optional) Contains either absolute path to GPG keyring or embedded GPG public key block, if not set APT uses all trusted keys;
+    /// I can't find example of using with fingerprints
+    fn signature(&self) -> Option<Cow<'_, Signature>>;
+    /// alias signed_by
+
+    /// (Optional) Field ignored by APT but used by RepoLib to identify repositories, Ubuntu sources contain them
+    fn x_repolib_name(&self) -> Option<Cow<'_, str>>; // this supports RepoLib still used by PopOS, even if removed from Debian/Ubuntu
+
+    /// (Optional) Field not present in the man page, but used in APT unit tests, potentially to hold the repository description
+    fn description(&self) -> Option<Cow<'_, str>>;
+}


### PR DESCRIPTION
> [!IMPORTANT]
> This is in the _ideation_ stage, not supposed to be merged without any real life proof of sense.

I made attempt to create a trait shared between `lossy` and `lossless` variants of `Repository`, but this has following flaws:
* Interface over `lossy` variant works nice as we can refer to member; I tried `Cow<>` but now dealing with fact `Paragraph::get()` may fail become a problem (`unwrap()` is plain wrong).
* Use `Cow<>` is going to work for some cases, but may be a problem for some others, especially if wrapped in `Option<>`
* For optional fields use of `.ok()` turns potential errors of late parsing into `None`, I have doubts if it's acceptable.

Problems with `lossless` structure:
* `Paragraph`s are copied out of `Deb822`, there's not reference to them
* If `lossless::Repositories` store `Deb822`, I can only create `lossless::Repository` from these paragraphs, there's not way to return reference to them (that's different than in `lossy` variant).

Maybe I'm heading in wrong direction (no modifications/setting taken into account yet), as this route gives me _identical_ API of both variants, but with problems. Maybe the role of lossless variant should be to produce out lossy variant and accept one to perform modifications.

Can we discuss pros and cons?