### PR TITLE
Add `#[derive(Debug)]` into `ast_node!()` macro (fixes #206)

### DIFF
--- a/src/lossless.rs
+++ b/src/lossless.rs
@@ -309,7 +309,7 @@ macro_rules! ast_node {
         #[doc = "An AST node representing a `"]
         #[doc = stringify!($ast)]
         #[doc = "`."]
-        #[derive(PartialEq, Eq, Hash)]
+        #[derive(Debug, PartialEq, Eq, Hash)]
         #[repr(transparent)]
         pub struct $ast(SyntaxNode);
         impl $ast {
@@ -345,12 +345,6 @@ macro_rules! ast_node {
             }
         }
     };
-}
-
-impl std::fmt::Debug for Deb822 {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Deb822").finish()
-    }
 }
 
 ast_node!(Deb822, ROOT);


### PR DESCRIPTION
## Purpose

If subclasses of the lossless parser don't implement `Debug` types using them cannot derive `Debug` and in result cannot directly participate in tests' assertions. This just adds `#[derive(Debug)]` into the `ast_node!()` macro, so all three parser types have implementations in result.
