### PR TITLE
fix(apt-sources): fix sources file contains flat repo entry parse

### DIFF
--- a/apt-sources/src/lib.rs
+++ b/apt-sources/src/lib.rs
@@ -354,6 +354,19 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_flat_repo() {
+        let s = indoc! {r#"
+            Types: deb
+            URIs: http://ports.ubuntu.com/
+            Suites: ./
+            Architectures: arm64
+        "#};
+
+        let repos = s.parse::<Repositories>().expect("Shall be parsed flawlessly");
+        assert!(repos[0].types.contains(&super::RepositoryType::Binary));
+    }
+
+    #[test]
     fn test_parse_w_keyblock() {
         let s = indoc!(r#"
             Types: deb

--- a/apt-sources/src/lib.rs
+++ b/apt-sources/src/lib.rs
@@ -228,9 +228,10 @@ pub struct Repository {
     /// The distribution name as codename or suite type (like `stable` or `testing`)
     #[deb822(field = "Suites", deserialize_with = deserialize_string_chain, serialize_with = serialize_string_chain)]
     suites: Vec<String>,
-    /// Section of the repository, usually `main`, `contrib` or `non-free`
+    /// (Optional) Section of the repository, usually `main`, `contrib` or `non-free`
+    /// return `None` if repository is Flat Repository Format (https://wiki.debian.org/DebianRepository/Format#Flat_Repository_Format)
     #[deb822(field = "Components", deserialize_with = deserialize_string_chain, serialize_with = serialize_string_chain)]
-    components: Vec<String>,
+    components: Option<Vec<String>>,
 
     /// (Optional) Architectures binaries from this repository run on
     #[deb822(field = "Architectures", deserialize_with = deserialize_string_chain, serialize_with = serialize_string_chain)]
@@ -404,7 +405,7 @@ mod tests {
                 architectures: vec!["arm64".to_owned()],
                 uris: vec![Url::from_str("https://deb.debian.org/debian").unwrap()],
                 suites: vec!["jammy".to_owned()],
-                components: vec!["main". to_owned()],
+                components: vec!["main". to_owned()].into(),
                 signature: None,
                 x_repolib_name: None,
                 languages: None,


### PR DESCRIPTION
See https://wiki.debian.org/DebianRepository/Format#Flat_Repository_Format, flat repo has no components