### PR TITLE
Add positioned parse errors to deb822-lossless

### DIFF
--- a/deb822-lossless/src/lib.rs
+++ b/deb822-lossless/src/lib.rs
@@ -8,7 +8,7 @@ mod common;
 mod lex;
 mod lossless;
 mod parse;
-pub use lossless::{Deb822, Entry, Error, Lang, Paragraph, ParseError};
+pub use lossless::{Deb822, Entry, Error, Lang, Paragraph, ParseError, PositionedParseError};
 pub use parse::Parse;
 pub use rowan::TextRange;
 

--- a/deb822-lossless/src/parse.rs
+++ b/deb822-lossless/src/parse.rs
@@ -1,6 +1,6 @@
 //! Parse wrapper type following rust-analyzer's pattern for thread-safe storage in Salsa.
 
-use crate::lossless::{Deb822, ParseError};
+use crate::lossless::{Deb822, ParseError, PositionedParseError};
 use rowan::ast::AstNode;
 use rowan::{GreenNode, SyntaxNode};
 use std::marker::PhantomData;
@@ -13,6 +13,7 @@ use std::marker::PhantomData;
 pub struct Parse<T> {
     green: GreenNode,
     errors: Vec<String>,
+    positioned_errors: Vec<PositionedParseError>,
     _ty: PhantomData<T>,
 }
 
@@ -22,6 +23,21 @@ impl<T> Parse<T> {
         Parse {
             green,
             errors,
+            positioned_errors: Vec::new(),
+            _ty: PhantomData,
+        }
+    }
+
+    /// Create a new Parse result from a GreenNode, errors, and positioned errors
+    pub fn new_with_positioned_errors(
+        green: GreenNode,
+        errors: Vec<String>,
+        positioned_errors: Vec<PositionedParseError>,
+    ) -> Self {
+        Parse {
+            green,
+            errors,
+            positioned_errors,
             _ty: PhantomData,
         }
     }
@@ -34,6 +50,19 @@ impl<T> Parse<T> {
     /// Get the syntax errors
     pub fn errors(&self) -> &[String] {
         &self.errors
+    }
+
+    /// Get parse errors with position information
+    pub fn positioned_errors(&self) -> &[PositionedParseError] {
+        &self.positioned_errors
+    }
+
+    /// Get parse errors as strings (for backward compatibility if needed)
+    pub fn error_messages(&self) -> Vec<String> {
+        self.positioned_errors
+            .iter()
+            .map(|e| e.message.clone())
+            .collect()
     }
 
     /// Check if there are any errors
@@ -78,10 +107,68 @@ impl<T> Parse<T> {
 unsafe impl<T> Send for Parse<T> {}
 unsafe impl<T> Sync for Parse<T> {}
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_positioned_errors_api() {
+        let input = "Invalid field without colon\nBroken: field: extra colon\n";
+        let parsed = Parse::<Deb822>::parse_deb822(input);
+
+        // Should have positioned errors
+        let positioned_errors = parsed.positioned_errors();
+        assert!(!positioned_errors.is_empty());
+
+        // Should still have string errors for backward compatibility
+        let string_errors = parsed.errors();
+        assert!(!string_errors.is_empty());
+
+        // Should be able to get error messages
+        let error_messages = parsed.error_messages();
+        assert_eq!(error_messages.len(), positioned_errors.len());
+
+        for (i, positioned_error) in positioned_errors.iter().enumerate() {
+            assert_eq!(positioned_error.message, error_messages[i]);
+            assert!(positioned_error.range.start() <= positioned_error.range.end());
+        }
+    }
+
+    #[test]
+    fn test_positioned_errors_example() {
+        // Example from the requirements document
+        let input = "Invalid: field\nBroken field without colon";
+        let parsed = Parse::<Deb822>::parse_deb822(input);
+
+        let positioned_errors = parsed.positioned_errors();
+        assert!(!positioned_errors.is_empty());
+
+        // Example usage like in a language server
+        for error in positioned_errors {
+            let start_offset: u32 = error.range.start().into();
+            let end_offset: u32 = error.range.end().into();
+            println!(
+                "Error at {:?} ({}..{}): {}",
+                error.range, start_offset, end_offset, error.message
+            );
+
+            // Verify we can extract the problematic text
+            if end_offset <= input.len() as u32 {
+                let error_text = &input[start_offset as usize..end_offset as usize];
+                assert!(!error_text.is_empty());
+            }
+        }
+    }
+}
+
 impl Parse<Deb822> {
     /// Parse deb822 text, returning a Parse result
     pub fn parse_deb822(text: &str) -> Self {
         let parsed = crate::lossless::parse(text);
-        Parse::new(parsed.green_node, parsed.errors)
+        Parse::new_with_positioned_errors(
+            parsed.green_node,
+            parsed.errors,
+            parsed.positioned_errors,
+        )
     }
 }


### PR DESCRIPTION
Implements PositionedParseError struct with TextRange information to enable precise error location reporting for language servers and IDEs.