### PR TITLE
deb822-lossless: Add robust error recovery support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -458,7 +458,7 @@ dependencies = [
 
 [[package]]
 name = "debian-copyright"
-version = "0.1.27"
+version = "0.1.28"
 dependencies = [
  "deb822-fast",
  "deb822-lossless",

--- a/deb822-lossless/examples/error_recovery.rs
+++ b/deb822-lossless/examples/error_recovery.rs
@@ -1,0 +1,204 @@
+//! Example demonstrating error recovery in the deb822-lossless parser.
+//!
+//! This example shows how the parser can handle malformed deb822 files gracefully,
+//! continuing to parse valid content even when errors are encountered.
+
+use deb822_lossless::Deb822;
+use std::collections::HashMap;
+
+fn main() {
+    // Example 1: Missing colons
+    println!("=== Example 1: Missing Colons ===");
+    let malformed_input1 = r#"Source: test-package
+Maintainer John Doe <john@example.com>
+Section: utils
+Version: 1.0.0
+
+Package: test-package
+Architecture: all
+Description: A test package
+ This is a multi-line description
+ that spans multiple lines.
+"#;
+
+    demonstrate_error_recovery("Missing colon after Maintainer", malformed_input1);
+
+    // Example 2: Orphaned text and missing field names
+    println!("\n=== Example 2: Orphaned Text and Missing Field Names ===");
+    let malformed_input2 = r#"Package: my-package
+some random text without a field name
+: orphaned colon without field name
+Version: 2.0.0
+Description: Valid description
+"#;
+
+    demonstrate_error_recovery("Orphaned text and colon", malformed_input2);
+
+    // Example 3: Consecutive field names (missing values)
+    println!("\n=== Example 3: Consecutive Field Names ===");
+    let malformed_input3 = r#"Package: another-package
+Maintainer
+Priority
+Section: devel
+Description: Another package
+Version: 3.0.0
+"#;
+
+    demonstrate_error_recovery("Missing values for some fields", malformed_input3);
+
+    // Example 4: Mixed errors across paragraphs
+    println!("\n=== Example 4: Mixed Errors Across Paragraphs ===");
+    let malformed_input4 = r#"Source broken-source
+Maintainer: Valid Maintainer <valid@example.com>
+
+completely broken paragraph here
+: orphaned stuff
+random text everywhere
+
+Package: recovered-package
+Architecture: all
+Depends: some-dep
+Description: This package was recovered after errors
+"#;
+
+    demonstrate_error_recovery("Mixed errors across paragraphs", malformed_input4);
+
+    // Example 5: Malformed continuation lines
+    println!("\n=== Example 5: Malformed Continuation Lines ===");
+    let malformed_input5 = r#"Package: continuation-test
+Description: Short description
+  Proper continuation line
+invalid continuation without indent
+ Another proper continuation
+  Last proper continuation
+Version: 1.0
+"#;
+
+    demonstrate_error_recovery("Malformed continuation lines", malformed_input5);
+}
+
+fn demonstrate_error_recovery(title: &str, input: &str) {
+    println!("Input ({}):", title);
+    println!("{}", input);
+
+    // Parse with error recovery
+    let (deb822, errors) = Deb822::from_str_relaxed(input);
+
+    // Show errors found
+    if !errors.is_empty() {
+        println!("Errors found:");
+        for (i, error) in errors.iter().enumerate() {
+            println!("  {}: {}", i + 1, error);
+        }
+    } else {
+        println!("No errors found.");
+    }
+
+    // Show positioned errors if available
+    let parsed = Deb822::parse(input);
+    let positioned_errors = parsed.positioned_errors();
+    if !positioned_errors.is_empty() {
+        println!("\nPositioned errors:");
+        for (i, error) in positioned_errors.iter().enumerate() {
+            println!(
+                "  {}: {} (range: {:?}, code: {:?})",
+                i + 1,
+                error.message,
+                error.range,
+                error.code
+            );
+
+            // Show the problematic text
+            let start = error.range.start().into();
+            let end = error.range.end().into();
+            if end <= input.len() {
+                let error_text = &input[start..end];
+                if !error_text.is_empty() {
+                    println!("     Problematic text: {:?}", error_text);
+                }
+            }
+        }
+    }
+
+    // Show recovered structure
+    println!("\nRecovered structure:");
+    println!("  Number of paragraphs: {}", deb822.paragraphs().count());
+
+    // Collect all valid fields from all paragraphs
+    let mut all_fields: HashMap<String, String> = HashMap::new();
+    for (i, paragraph) in deb822.paragraphs().enumerate() {
+        let fields: Vec<String> = paragraph.keys().collect();
+        if !fields.is_empty() {
+            println!("  Paragraph {}: {} fields", i + 1, fields.len());
+            for field in &fields {
+                println!(
+                    "    {}: {:?}",
+                    field,
+                    paragraph.get(field).unwrap_or_default()
+                );
+                all_fields.insert(field.clone(), paragraph.get(field).unwrap_or_default());
+            }
+        } else {
+            println!(
+                "  Paragraph {}: No valid fields (error recovery paragraph)",
+                i + 1
+            );
+        }
+    }
+
+    // Show that we can still work with the recovered data
+    println!("\nUsable extracted data:");
+    for (key, value) in &all_fields {
+        println!("  {}: {}", key, value);
+    }
+
+    // Demonstrate that the structure is still lossless - we can reconstruct the original
+    println!("\nReconstructed output (preserves original formatting):");
+    let reconstructed = deb822.to_string();
+    println!("{}", reconstructed);
+
+    println!("{}", "=".repeat(60));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_error_recovery_examples() {
+        // Test that all examples in main() actually work
+        let examples = [
+            r#"Source: test
+Maintainer Bad Format
+Section: utils"#,
+            r#"Package: test
+orphaned text
+Version: 1.0"#,
+            r#"Package: test
+Field1
+Field2
+Valid: field"#,
+        ];
+
+        for (i, example) in examples.iter().enumerate() {
+            let (deb822, errors) = Deb822::from_str_relaxed(example);
+
+            // Should have errors but still parse something useful
+            assert!(!errors.is_empty(), "Example {} should have errors", i);
+
+            // Should still extract some valid fields
+            let mut all_fields = HashMap::new();
+            for paragraph in deb822.paragraphs() {
+                for (key, value) in paragraph.items() {
+                    all_fields.insert(key, value);
+                }
+            }
+
+            assert!(
+                !all_fields.is_empty(),
+                "Example {} should extract some valid fields",
+                i
+            );
+        }
+    }
+}

--- a/deb822-lossless/src/lossless.rs
+++ b/deb822-lossless/src/lossless.rs
@@ -161,7 +161,47 @@ pub(crate) fn parse(text: &str) -> Parse {
     }
 
     impl<'a> Parser<'a> {
+        /// Skip to next paragraph boundary for error recovery
+        fn skip_to_paragraph_boundary(&mut self) {
+            while self.current().is_some() {
+                match self.current() {
+                    Some(NEWLINE) => {
+                        self.bump();
+                        // Check if next line starts a new paragraph (key at start of line)
+                        if self.at_paragraph_start() {
+                            break;
+                        }
+                    }
+                    _ => {
+                        self.bump();
+                    }
+                }
+            }
+        }
+
+        /// Check if we're at the start of a new paragraph
+        fn at_paragraph_start(&self) -> bool {
+            match self.current() {
+                Some(KEY) => true,
+                Some(COMMENT) => true,
+                None => true, // EOF is a valid paragraph boundary
+                _ => false,
+            }
+        }
+
+        /// Attempt to recover from entry parsing errors
+        fn recover_entry(&mut self) {
+            // Skip to end of current line
+            while self.current().is_some() && self.current() != Some(NEWLINE) {
+                self.bump();
+            }
+            // Consume the newline if present
+            if self.current() == Some(NEWLINE) {
+                self.bump();
+            }
+        }
         fn parse_entry(&mut self) {
+            // Handle leading comments
             while self.current() == Some(COMMENT) {
                 self.bump();
 
@@ -175,46 +215,120 @@ pub(crate) fn parse(text: &str) -> Parse {
                     Some(g) => {
                         self.builder.start_node(ERROR.into());
                         self.add_positioned_error(
-                            format!("expected newline, got {g:?}"),
-                            Some("unexpected_token".to_string()),
+                            format!("expected newline after comment, got {g:?}"),
+                            Some("unexpected_token_after_comment".to_string()),
                         );
                         self.bump();
                         self.builder.finish_node();
+                        self.recover_entry();
+                        return;
                     }
                 }
             }
 
             self.builder.start_node(ENTRY.into());
+            let mut entry_has_errors = false;
 
-            // First, parse the key and colon
+            // Parse the key
             if self.current() == Some(KEY) {
                 self.bump();
                 self.skip_ws();
             } else {
+                entry_has_errors = true;
                 self.builder.start_node(ERROR.into());
-                self.add_positioned_error(
-                    "expected key".to_string(),
-                    Some("missing_key".to_string()),
-                );
-                if self.current().is_some() {
-                    self.bump();
+
+                // Enhanced error recovery for malformed keys
+                match self.current() {
+                    Some(VALUE) | Some(WHITESPACE) => {
+                        self.add_positioned_error(
+                            "field name cannot start with whitespace or special characters"
+                                .to_string(),
+                            Some("invalid_field_name".to_string()),
+                        );
+                        // Try to consume what might be an intended key
+                        while self.current() == Some(VALUE) || self.current() == Some(WHITESPACE) {
+                            self.bump();
+                        }
+                    }
+                    Some(COLON) => {
+                        self.add_positioned_error(
+                            "field name missing before colon".to_string(),
+                            Some("missing_field_name".to_string()),
+                        );
+                    }
+                    Some(NEWLINE) => {
+                        self.add_positioned_error(
+                            "empty line where field expected".to_string(),
+                            Some("empty_field_line".to_string()),
+                        );
+                        self.builder.finish_node();
+                        self.builder.finish_node();
+                        return;
+                    }
+                    _ => {
+                        self.add_positioned_error(
+                            format!("expected field name, got {:?}", self.current()),
+                            Some("missing_key".to_string()),
+                        );
+                        if self.current().is_some() {
+                            self.bump();
+                        }
+                    }
                 }
                 self.builder.finish_node();
             }
+
+            // Parse the colon
             if self.current() == Some(COLON) {
                 self.bump();
                 self.skip_ws();
             } else {
+                entry_has_errors = true;
                 self.builder.start_node(ERROR.into());
-                self.add_positioned_error(
-                    format!("expected ':', got {:?}", self.current()),
-                    Some("missing_colon".to_string()),
-                );
-                if self.current().is_some() {
-                    self.bump();
+
+                // Enhanced error recovery for missing colon
+                match self.current() {
+                    Some(VALUE) => {
+                        self.add_positioned_error(
+                            "missing colon ':' after field name".to_string(),
+                            Some("missing_colon".to_string()),
+                        );
+                        // Don't consume the value, let it be parsed as the field value
+                    }
+                    Some(NEWLINE) => {
+                        self.add_positioned_error(
+                            "field name without value (missing colon and value)".to_string(),
+                            Some("incomplete_field".to_string()),
+                        );
+                        self.builder.finish_node();
+                        self.builder.finish_node();
+                        return;
+                    }
+                    Some(KEY) => {
+                        self.add_positioned_error(
+                            "field name followed by another field name (missing colon and value)"
+                                .to_string(),
+                            Some("consecutive_field_names".to_string()),
+                        );
+                        // Don't consume the next key, let it be parsed as a new entry
+                        self.builder.finish_node();
+                        self.builder.finish_node();
+                        return;
+                    }
+                    _ => {
+                        self.add_positioned_error(
+                            format!("expected colon ':', got {:?}", self.current()),
+                            Some("missing_colon".to_string()),
+                        );
+                        if self.current().is_some() {
+                            self.bump();
+                        }
+                    }
                 }
                 self.builder.finish_node();
             }
+
+            // Parse the value (potentially multi-line)
             loop {
                 while self.current() == Some(WHITESPACE) || self.current() == Some(VALUE) {
                     self.bump();
@@ -227,16 +341,22 @@ pub(crate) fn parse(text: &str) -> Parse {
                     Some(NEWLINE) => {
                         self.bump();
                     }
+                    Some(KEY) => {
+                        // We've hit another field, this entry is complete
+                        break;
+                    }
                     Some(g) => {
                         self.builder.start_node(ERROR.into());
                         self.add_positioned_error(
-                            format!("expected newline, got {g:?}"),
-                            Some("unexpected_token".to_string()),
+                            format!("unexpected token in field value: {g:?}"),
+                            Some("unexpected_value_token".to_string()),
                         );
                         self.bump();
                         self.builder.finish_node();
                     }
                 }
+
+                // Check for continuation lines
                 if self.current() == Some(INDENT) {
                     self.bump();
                     self.skip_ws();
@@ -244,14 +364,91 @@ pub(crate) fn parse(text: &str) -> Parse {
                     break;
                 }
             }
+
             self.builder.finish_node();
+
+            // If the entry had errors, we might want to recover
+            if entry_has_errors && !self.at_paragraph_start() && self.current().is_some() {
+                self.recover_entry();
+            }
         }
 
         fn parse_paragraph(&mut self) {
             self.builder.start_node(PARAGRAPH.into());
+
+            let mut consecutive_errors = 0;
+            const MAX_CONSECUTIVE_ERRORS: usize = 5;
+
             while self.current() != Some(NEWLINE) && self.current().is_some() {
-                self.parse_entry();
+                let error_count_before = self.positioned_errors.len();
+
+                // Check if we're at a valid entry start
+                if self.current() == Some(KEY) || self.current() == Some(COMMENT) {
+                    self.parse_entry();
+
+                    // Reset consecutive error count if we successfully parsed something
+                    if self.positioned_errors.len() == error_count_before {
+                        consecutive_errors = 0;
+                    } else {
+                        consecutive_errors += 1;
+                    }
+                } else {
+                    // We're not at a valid entry start, this is an error
+                    consecutive_errors += 1;
+
+                    self.builder.start_node(ERROR.into());
+                    match self.current() {
+                        Some(VALUE) => {
+                            self.add_positioned_error(
+                                "orphaned text without field name".to_string(),
+                                Some("orphaned_text".to_string()),
+                            );
+                            // Consume the orphaned text
+                            while self.current() == Some(VALUE)
+                                || self.current() == Some(WHITESPACE)
+                            {
+                                self.bump();
+                            }
+                        }
+                        Some(COLON) => {
+                            self.add_positioned_error(
+                                "orphaned colon without field name".to_string(),
+                                Some("orphaned_colon".to_string()),
+                            );
+                            self.bump();
+                        }
+                        Some(INDENT) => {
+                            self.add_positioned_error(
+                                "unexpected indentation without field".to_string(),
+                                Some("unexpected_indent".to_string()),
+                            );
+                            self.bump();
+                        }
+                        _ => {
+                            self.add_positioned_error(
+                                format!(
+                                    "unexpected token at paragraph level: {:?}",
+                                    self.current()
+                                ),
+                                Some("unexpected_paragraph_token".to_string()),
+                            );
+                            self.bump();
+                        }
+                    }
+                    self.builder.finish_node();
+                }
+
+                // If we have too many consecutive errors, skip to paragraph boundary
+                if consecutive_errors >= MAX_CONSECUTIVE_ERRORS {
+                    self.add_positioned_error(
+                        "too many consecutive parse errors, skipping to next paragraph".to_string(),
+                        Some("parse_recovery".to_string()),
+                    );
+                    self.skip_to_paragraph_boundary();
+                    break;
+                }
             }
+
             self.builder.finish_node();
         }
 
@@ -2103,5 +2300,249 @@ Version: 1.0"#;
         assert!(colon_range.end() <= value_range.start());
         assert!(key_range.start() >= text_range.start());
         assert!(value_range.end() <= text_range.end());
+    }
+
+    #[test]
+    fn test_error_recovery_missing_colon() {
+        let input = r#"Source foo
+Maintainer: Test User <test@example.com>
+"#;
+        let (deb822, errors) = super::Deb822::from_str_relaxed(input);
+
+        // Should still parse successfully with errors
+        assert!(!errors.is_empty());
+        assert!(errors.iter().any(|e| e.contains("missing colon")));
+
+        // Should still have a paragraph with the valid field
+        let paragraph = deb822.paragraphs().next().unwrap();
+        assert_eq!(
+            paragraph.get("Maintainer").as_deref(),
+            Some("Test User <test@example.com>")
+        );
+    }
+
+    #[test]
+    fn test_error_recovery_missing_field_name() {
+        let input = r#": orphaned value
+Package: test
+"#;
+
+        let (deb822, errors) = super::Deb822::from_str_relaxed(input);
+
+        // Should have errors about missing field name
+        assert!(!errors.is_empty());
+        assert!(errors
+            .iter()
+            .any(|e| e.contains("field name") || e.contains("missing")));
+
+        // The valid field should be in one of the paragraphs
+        let paragraphs: Vec<_> = deb822.paragraphs().collect();
+        let mut found_package = false;
+        for paragraph in paragraphs.iter() {
+            if paragraph.get("Package").is_some() {
+                found_package = true;
+                assert_eq!(paragraph.get("Package").as_deref(), Some("test"));
+            }
+        }
+        assert!(found_package, "Package field not found in any paragraph");
+    }
+
+    #[test]
+    fn test_error_recovery_orphaned_text() {
+        let input = r#"Package: test
+some orphaned text without field name
+Version: 1.0
+"#;
+        let (deb822, errors) = super::Deb822::from_str_relaxed(input);
+
+        // Should have errors about orphaned text
+        assert!(!errors.is_empty());
+        assert!(errors.iter().any(|e| e.contains("orphaned")
+            || e.contains("unexpected")
+            || e.contains("field name")));
+
+        // Should still parse the valid fields (may be split across paragraphs)
+        let mut all_fields = std::collections::HashMap::new();
+        for paragraph in deb822.paragraphs() {
+            for (key, value) in paragraph.items() {
+                all_fields.insert(key, value);
+            }
+        }
+
+        assert_eq!(all_fields.get("Package"), Some(&"test".to_string()));
+        assert_eq!(all_fields.get("Version"), Some(&"1.0".to_string()));
+    }
+
+    #[test]
+    fn test_error_recovery_consecutive_field_names() {
+        let input = r#"Package: test
+Description
+Maintainer: Another field without proper value
+Version: 1.0
+"#;
+        let (deb822, errors) = super::Deb822::from_str_relaxed(input);
+
+        // Should have errors about missing values
+        assert!(!errors.is_empty());
+        assert!(errors.iter().any(|e| e.contains("consecutive")
+            || e.contains("missing")
+            || e.contains("incomplete")));
+
+        // Should still parse valid fields (may be split across paragraphs due to errors)
+        let mut all_fields = std::collections::HashMap::new();
+        for paragraph in deb822.paragraphs() {
+            for (key, value) in paragraph.items() {
+                all_fields.insert(key, value);
+            }
+        }
+
+        assert_eq!(all_fields.get("Package"), Some(&"test".to_string()));
+        assert_eq!(
+            all_fields.get("Maintainer"),
+            Some(&"Another field without proper value".to_string())
+        );
+        assert_eq!(all_fields.get("Version"), Some(&"1.0".to_string()));
+    }
+
+    #[test]
+    fn test_error_recovery_malformed_multiline() {
+        let input = r#"Package: test
+Description: Short desc
+  Proper continuation
+invalid continuation without indent
+ Another proper continuation
+Version: 1.0
+"#;
+        let (deb822, errors) = super::Deb822::from_str_relaxed(input);
+
+        // Should recover from malformed continuation
+        assert!(!errors.is_empty());
+
+        // Should still parse other fields correctly
+        let paragraph = deb822.paragraphs().next().unwrap();
+        assert_eq!(paragraph.get("Package").as_deref(), Some("test"));
+        assert_eq!(paragraph.get("Version").as_deref(), Some("1.0"));
+    }
+
+    #[test]
+    fn test_error_recovery_mixed_errors() {
+        let input = r#"Package test without colon
+: orphaned colon
+Description: Valid field
+some orphaned text
+Another-Field: Valid too
+"#;
+        let (deb822, errors) = super::Deb822::from_str_relaxed(input);
+
+        // Should have multiple different errors
+        assert!(!errors.is_empty());
+        assert!(errors.len() >= 2);
+
+        // Should still parse the valid fields
+        let paragraph = deb822.paragraphs().next().unwrap();
+        assert_eq!(paragraph.get("Description").as_deref(), Some("Valid field"));
+        assert_eq!(paragraph.get("Another-Field").as_deref(), Some("Valid too"));
+    }
+
+    #[test]
+    fn test_error_recovery_paragraph_boundary() {
+        let input = r#"Package: first-package
+Description: First paragraph
+
+corrupted data here
+: more corruption
+completely broken line
+
+Package: second-package
+Version: 1.0
+"#;
+        let (deb822, errors) = super::Deb822::from_str_relaxed(input);
+
+        // Should have errors from the corrupted section
+        assert!(!errors.is_empty());
+
+        // Should still parse both paragraphs correctly
+        let paragraphs: Vec<_> = deb822.paragraphs().collect();
+        assert_eq!(paragraphs.len(), 2);
+
+        assert_eq!(
+            paragraphs[0].get("Package").as_deref(),
+            Some("first-package")
+        );
+        assert_eq!(
+            paragraphs[1].get("Package").as_deref(),
+            Some("second-package")
+        );
+        assert_eq!(paragraphs[1].get("Version").as_deref(), Some("1.0"));
+    }
+
+    #[test]
+    fn test_error_recovery_with_positioned_errors() {
+        let input = r#"Package test
+Description: Valid
+"#;
+        let parsed = super::parse(input);
+
+        // Should have positioned errors with proper ranges
+        assert!(!parsed.positioned_errors.is_empty());
+
+        let first_error = &parsed.positioned_errors[0];
+        assert!(!first_error.message.is_empty());
+        assert!(first_error.range.start() <= first_error.range.end());
+        assert!(first_error.code.is_some());
+
+        // Error should point to the problematic location
+        let error_text = &input[first_error.range.start().into()..first_error.range.end().into()];
+        assert!(!error_text.is_empty());
+    }
+
+    #[test]
+    fn test_error_recovery_preserves_whitespace() {
+        let input = r#"Source: package
+Maintainer   Test User <test@example.com>
+Section:    utils
+
+"#;
+        let (deb822, errors) = super::Deb822::from_str_relaxed(input);
+
+        // Should have error about missing colon
+        assert!(!errors.is_empty());
+
+        // Should preserve original formatting in output
+        let output = deb822.to_string();
+        assert!(output.contains("Section:    utils"));
+
+        // Should still extract valid fields
+        let paragraph = deb822.paragraphs().next().unwrap();
+        assert_eq!(paragraph.get("Source").as_deref(), Some("package"));
+        assert_eq!(paragraph.get("Section").as_deref(), Some("utils"));
+    }
+
+    #[test]
+    fn test_error_recovery_empty_fields() {
+        let input = r#"Package: test
+Description:
+Maintainer: Valid User
+EmptyField: 
+Version: 1.0
+"#;
+        let (deb822, _errors) = super::Deb822::from_str_relaxed(input);
+
+        // Empty fields should parse without major errors - collect all fields from all paragraphs
+        let mut all_fields = std::collections::HashMap::new();
+        for paragraph in deb822.paragraphs() {
+            for (key, value) in paragraph.items() {
+                all_fields.insert(key, value);
+            }
+        }
+
+        assert_eq!(all_fields.get("Package"), Some(&"test".to_string()));
+        assert_eq!(all_fields.get("Description"), Some(&"".to_string()));
+        assert_eq!(
+            all_fields.get("Maintainer"),
+            Some(&"Valid User".to_string())
+        );
+        assert_eq!(all_fields.get("EmptyField"), Some(&"".to_string()));
+        assert_eq!(all_fields.get("Version"), Some(&"1.0".to_string()));
     }
 }


### PR DESCRIPTION
Add error recovery capabilities to the deb822-lossless parser:

* Enhanced parser recovery strategies:
  - Skip to paragraph boundary when encountering consecutive errors
  - Entry-level recovery for malformed entries
  - Consecutive error limit to prevent infinite loops

* Improved error detection and handling:
  - Missing field names (orphaned colons)
  - Missing colons after field names
  - Orphaned text without proper field structure
  - Consecutive field names without values
  - Malformed continuation lines

* Positioned error information:
  - Text ranges with precise location information using rowan::TextRange
  - Error codes for programmatic handling

* Robust recovery mechanisms:
  - Paragraph-level recovery skips corrupted sections while preserving valid paragraphs
  - Field preservation - valid fields are preserved even when surrounding content has errors
  - Whitespace preservation - original formatting is maintained even in error scenarios