### PR TITLE
Add set() methods that honor canonical field ordering

### DIFF
--- a/deb822-lossless/src/lib.rs
+++ b/deb822-lossless/src/lib.rs
@@ -8,7 +8,10 @@ mod common;
 mod lex;
 mod lossless;
 mod parse;
-pub use lossless::{Deb822, Entry, Error, Lang, Paragraph, ParseError, PositionedParseError};
+pub use lossless::{
+    Deb822, Entry, Error, Lang, Paragraph, ParseError, PositionedParseError, BINARY_FIELD_ORDER,
+    SOURCE_FIELD_ORDER,
+};
 pub use parse::Parse;
 pub use rowan::TextRange;
 

--- a/deb822-lossless/src/lossless.rs
+++ b/deb822-lossless/src/lossless.rs
@@ -42,6 +42,57 @@ use rowan::ast::AstNode;
 use std::path::Path;
 use std::str::FromStr;
 
+/// Canonical field order for source paragraphs in debian/control files
+pub const SOURCE_FIELD_ORDER: &[&str] = &[
+    "Source",
+    "Section",
+    "Priority",
+    "Maintainer",
+    "Uploaders",
+    "Build-Depends",
+    "Build-Depends-Indep",
+    "Build-Depends-Arch",
+    "Build-Conflicts",
+    "Build-Conflicts-Indep",
+    "Build-Conflicts-Arch",
+    "Standards-Version",
+    "Vcs-Browser",
+    "Vcs-Git",
+    "Vcs-Svn",
+    "Vcs-Bzr",
+    "Vcs-Hg",
+    "Vcs-Darcs",
+    "Vcs-Cvs",
+    "Vcs-Arch",
+    "Vcs-Mtn",
+    "Homepage",
+    "Rules-Requires-Root",
+    "Testsuite",
+    "Testsuite-Triggers",
+];
+
+/// Canonical field order for binary packages in debian/control files
+pub const BINARY_FIELD_ORDER: &[&str] = &[
+    "Package",
+    "Architecture",
+    "Section",
+    "Priority",
+    "Multi-Arch",
+    "Essential",
+    "Build-Profiles",
+    "Built-Using",
+    "Pre-Depends",
+    "Depends",
+    "Recommends",
+    "Suggests",
+    "Enhances",
+    "Conflicts",
+    "Breaks",
+    "Replaces",
+    "Provides",
+    "Description",
+];
+
 /// A positioned parse error containing location information.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct PositionedParseError {
@@ -1103,10 +1154,11 @@ impl Paragraph {
         self.0.splice_children(count..count, vec![entry.0.into()]);
     }
 
-    /// Set a field in the paragraph
+    /// Set a field in the paragraph, inserting at the appropriate location if new
     pub fn set(&mut self, key: &str, value: &str) {
         let new_entry = Entry::new(key, value);
 
+        // Check if the field already exists and replace it
         for entry in self.entries() {
             if entry.key().as_deref() == Some(key) {
                 self.0.splice_children(
@@ -1116,9 +1168,128 @@ impl Paragraph {
                 return;
             }
         }
-        let count = self.0.children_with_tokens().count();
+
+        // Field doesn't exist, insert at appropriate location
+        // Try to detect if this is a source or binary package paragraph
+        let field_order = if self.contains_key("Source") {
+            SOURCE_FIELD_ORDER
+        } else if self.contains_key("Package") {
+            BINARY_FIELD_ORDER
+        } else {
+            // Default to trying both, preferring source if the new field is "Source"
+            if key == "Source" {
+                SOURCE_FIELD_ORDER
+            } else if key == "Package" {
+                BINARY_FIELD_ORDER
+            } else {
+                // Try to determine based on existing fields
+                let has_source_fields = self.keys().any(|k| {
+                    SOURCE_FIELD_ORDER.contains(&k.as_str())
+                        && !BINARY_FIELD_ORDER.contains(&k.as_str())
+                });
+                if has_source_fields {
+                    SOURCE_FIELD_ORDER
+                } else {
+                    BINARY_FIELD_ORDER
+                }
+            }
+        };
+
+        let insertion_index = self.find_insertion_index(key, field_order);
         self.0
-            .splice_children(count..count, vec![new_entry.0.into()]);
+            .splice_children(insertion_index..insertion_index, vec![new_entry.0.into()]);
+    }
+
+    /// Set a field using a specific field ordering
+    pub fn set_with_field_order(&mut self, key: &str, value: &str, field_order: &[&str]) {
+        let new_entry = Entry::new(key, value);
+
+        // Check if the field already exists and replace it
+        for entry in self.entries() {
+            if entry.key().as_deref() == Some(key) {
+                self.0.splice_children(
+                    entry.0.index()..entry.0.index() + 1,
+                    vec![new_entry.0.into()],
+                );
+                return;
+            }
+        }
+
+        let insertion_index = self.find_insertion_index(key, field_order);
+        self.0
+            .splice_children(insertion_index..insertion_index, vec![new_entry.0.into()]);
+    }
+
+    /// Find the appropriate insertion index for a new field based on field ordering
+    fn find_insertion_index(&self, key: &str, field_order: &[&str]) -> usize {
+        // Find position of the new field in the canonical order
+        let new_field_position = field_order.iter().position(|&field| field == key);
+
+        let mut insertion_index = self.0.children_with_tokens().count();
+
+        // Find the right position based on canonical field order
+        for (i, child) in self.0.children_with_tokens().enumerate() {
+            if let Some(node) = child.as_node() {
+                if let Some(entry) = Entry::cast(node.clone()) {
+                    if let Some(existing_key) = entry.key() {
+                        let existing_position =
+                            field_order.iter().position(|&field| field == existing_key);
+
+                        match (new_field_position, existing_position) {
+                            // Both fields are in the canonical order
+                            (Some(new_pos), Some(existing_pos)) => {
+                                if new_pos < existing_pos {
+                                    insertion_index = i;
+                                    break;
+                                }
+                            }
+                            // New field is in canonical order, existing is not
+                            (Some(_), None) => {
+                                // Continue looking - unknown fields go after known ones
+                            }
+                            // New field is not in canonical order, existing is
+                            (None, Some(_)) => {
+                                // Continue until we find all known fields
+                            }
+                            // Neither field is in canonical order, maintain alphabetical
+                            (None, None) => {
+                                if key < &existing_key {
+                                    insertion_index = i;
+                                    break;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // If we have a position in canonical order but haven't found where to insert yet,
+        // we need to insert after all known fields that come before it
+        if new_field_position.is_some() && insertion_index == self.0.children_with_tokens().count()
+        {
+            // Look for the position after the last known field that comes before our field
+            let children: Vec<_> = self.0.children_with_tokens().enumerate().collect();
+            for (i, child) in children.into_iter().rev() {
+                if let Some(node) = child.as_node() {
+                    if let Some(entry) = Entry::cast(node.clone()) {
+                        if let Some(existing_key) = entry.key() {
+                            if field_order
+                                .iter()
+                                .position(|&f| f == existing_key)
+                                .is_some()
+                            {
+                                // Found a known field, insert after it
+                                insertion_index = i + 1;
+                                break;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        insertion_index
     }
 
     /// Rename the given field in the paragraph.
@@ -2119,6 +2290,83 @@ C: D
     #[test]
     fn test_format_parse_error() {
         assert_eq!(ParseError(vec!["foo".to_string()]).to_string(), "foo\n");
+    }
+
+    #[test]
+    fn test_set_field_ordering_source() {
+        let mut p = super::Paragraph::new();
+
+        // Add fields in random order
+        p.set("Homepage", "https://example.com");
+        p.set("Source", "mypackage");
+        p.set("Build-Depends", "debhelper");
+        p.set("Maintainer", "Test <test@example.com>");
+        p.set("Standards-Version", "4.5.0");
+
+        // Check that fields are in the expected order
+        let keys: Vec<_> = p.keys().collect();
+        assert_eq!(keys[0], "Source");
+        assert_eq!(keys[1], "Maintainer");
+        assert_eq!(keys[2], "Build-Depends");
+        assert_eq!(keys[3], "Standards-Version");
+        assert_eq!(keys[4], "Homepage");
+    }
+
+    #[test]
+    fn test_set_field_ordering_binary() {
+        let mut p = super::Paragraph::new();
+
+        // Add fields in random order
+        p.set("Description", "A test package");
+        p.set("Package", "mypackage");
+        p.set("Depends", "libc6");
+        p.set("Architecture", "amd64");
+        p.set("Section", "utils");
+
+        // Check that fields are in the expected order
+        let keys: Vec<_> = p.keys().collect();
+        assert_eq!(keys[0], "Package");
+        assert_eq!(keys[1], "Architecture");
+        assert_eq!(keys[2], "Section");
+        assert_eq!(keys[3], "Depends");
+        assert_eq!(keys[4], "Description");
+    }
+
+    #[test]
+    fn test_set_field_ordering_mixed() {
+        let mut p = super::Paragraph::new();
+
+        // Add some known fields and some unknown fields
+        p.set("Package", "mypackage");
+        p.set("X-Custom-Field", "custom");
+        p.set("Architecture", "all");
+        p.set("Another-Custom", "value");
+        p.set("Description", "Test");
+
+        // Check that known fields are ordered correctly and unknown fields are alphabetical
+        let keys: Vec<_> = p.keys().collect();
+        assert_eq!(keys[0], "Package");
+        assert_eq!(keys[1], "Architecture");
+        assert_eq!(keys[2], "Description");
+        assert_eq!(keys[3], "Another-Custom"); // Unknown fields alphabetically sorted
+        assert_eq!(keys[4], "X-Custom-Field");
+    }
+
+    #[test]
+    fn test_set_with_field_order() {
+        let mut p = super::Paragraph::new();
+        let custom_order = &["Foo", "Bar", "Baz"];
+
+        p.set_with_field_order("Baz", "3", custom_order);
+        p.set_with_field_order("Foo", "1", custom_order);
+        p.set_with_field_order("Bar", "2", custom_order);
+        p.set_with_field_order("Unknown", "4", custom_order);
+
+        let keys: Vec<_> = p.keys().collect();
+        assert_eq!(keys[0], "Foo");
+        assert_eq!(keys[1], "Bar");
+        assert_eq!(keys[2], "Baz");
+        assert_eq!(keys[3], "Unknown");
     }
 
     #[test]

--- a/deb822-lossless/src/lossless.rs
+++ b/deb822-lossless/src/lossless.rs
@@ -1253,7 +1253,7 @@ impl Paragraph {
                             }
                             // Neither field is in canonical order, maintain alphabetical
                             (None, None) => {
-                                if key < &existing_key {
+                                if key < existing_key.as_str() {
                                     insertion_index = i;
                                     break;
                                 }

--- a/debian-control/src/lossless/control.rs
+++ b/debian-control/src/lossless/control.rs
@@ -34,7 +34,7 @@
 //! ```
 use crate::fields::{MultiArch, Priority};
 use crate::lossless::relations::Relations;
-use deb822_lossless::{Deb822, Paragraph};
+use deb822_lossless::{Deb822, Paragraph, BINARY_FIELD_ORDER, SOURCE_FIELD_ORDER};
 use rowan::ast::AstNode;
 
 fn format_field(name: &str, value: &str) -> String {
@@ -348,7 +348,7 @@ impl Source {
 
     /// Set the name of the source package.
     pub fn set_name(&mut self, name: &str) {
-        self.0.set("Source", name);
+        self.set("Source", name);
     }
 
     /// The default section of the packages built from this source package.
@@ -359,7 +359,7 @@ impl Source {
     /// Set the section of the source package
     pub fn set_section(&mut self, section: Option<&str>) {
         if let Some(section) = section {
-            self.0.set("Section", section);
+            self.set("Section", section);
         } else {
             self.0.remove("Section");
         }
@@ -373,7 +373,7 @@ impl Source {
     /// Set the priority of the source package
     pub fn set_priority(&mut self, priority: Option<Priority>) {
         if let Some(priority) = priority {
-            self.0.set("Priority", priority.to_string().as_str());
+            self.set("Priority", priority.to_string().as_str());
         } else {
             self.0.remove("Priority");
         }
@@ -386,7 +386,7 @@ impl Source {
 
     /// Set the maintainer of the package
     pub fn set_maintainer(&mut self, maintainer: &str) {
-        self.0.set("Maintainer", maintainer);
+        self.set("Maintainer", maintainer);
     }
 
     /// The build dependencies of the package.
@@ -396,7 +396,7 @@ impl Source {
 
     /// Set the Build-Depends field
     pub fn set_build_depends(&mut self, relations: &Relations) {
-        self.0.set("Build-Depends", relations.to_string().as_str());
+        self.set("Build-Depends", relations.to_string().as_str());
     }
 
     /// Return the Build-Depends-Indep field
@@ -437,7 +437,7 @@ impl Source {
 
     /// Set the Standards-Version field
     pub fn set_standards_version(&mut self, version: &str) {
-        self.0.set("Standards-Version", version);
+        self.set("Standards-Version", version);
     }
 
     /// Return the upstrea mHomepage
@@ -447,7 +447,7 @@ impl Source {
 
     /// Set the Homepage field
     pub fn set_homepage(&mut self, homepage: &url::Url) {
-        self.0.set("Homepage", homepage.to_string().as_str());
+        self.set("Homepage", homepage.to_string().as_str());
     }
 
     /// Return the Vcs-Git field
@@ -457,7 +457,7 @@ impl Source {
 
     /// Set the Vcs-Git field
     pub fn set_vcs_git(&mut self, url: &str) {
-        self.0.set("Vcs-Git", url);
+        self.set("Vcs-Git", url);
     }
 
     /// Return the Vcs-Browser field
@@ -467,7 +467,7 @@ impl Source {
 
     /// Set the Vcs-Svn field
     pub fn set_vcs_svn(&mut self, url: &str) {
-        self.0.set("Vcs-Svn", url);
+        self.set("Vcs-Svn", url);
     }
 
     /// Return the Vcs-Bzr field
@@ -477,7 +477,7 @@ impl Source {
 
     /// Set the Vcs-Bzr field
     pub fn set_vcs_bzr(&mut self, url: &str) {
-        self.0.set("Vcs-Bzr", url);
+        self.set("Vcs-Bzr", url);
     }
 
     /// Return the Vcs-Arch field
@@ -487,7 +487,7 @@ impl Source {
 
     /// Set the Vcs-Arch field
     pub fn set_vcs_arch(&mut self, url: &str) {
-        self.0.set("Vcs-Arch", url);
+        self.set("Vcs-Arch", url);
     }
 
     /// Return the Vcs-Svk field
@@ -497,7 +497,7 @@ impl Source {
 
     /// Set the Vcs-Svk field
     pub fn set_vcs_svk(&mut self, url: &str) {
-        self.0.set("Vcs-Svk", url);
+        self.set("Vcs-Svk", url);
     }
 
     /// Return the Vcs-Darcs field
@@ -507,7 +507,7 @@ impl Source {
 
     /// Set the Vcs-Darcs field
     pub fn set_vcs_darcs(&mut self, url: &str) {
-        self.0.set("Vcs-Darcs", url);
+        self.set("Vcs-Darcs", url);
     }
 
     /// Return the Vcs-Mtn field
@@ -517,7 +517,7 @@ impl Source {
 
     /// Set the Vcs-Mtn field
     pub fn set_vcs_mtn(&mut self, url: &str) {
-        self.0.set("Vcs-Mtn", url);
+        self.set("Vcs-Mtn", url);
     }
 
     /// Return the Vcs-Cvs field
@@ -527,7 +527,7 @@ impl Source {
 
     /// Set the Vcs-Cvs field
     pub fn set_vcs_cvs(&mut self, url: &str) {
-        self.0.set("Vcs-Cvs", url);
+        self.set("Vcs-Cvs", url);
     }
 
     /// Return the Vcs-Hg field
@@ -537,7 +537,12 @@ impl Source {
 
     /// Set the Vcs-Hg field
     pub fn set_vcs_hg(&mut self, url: &str) {
-        self.0.set("Vcs-Hg", url);
+        self.set("Vcs-Hg", url);
+    }
+
+    /// Set a field in the source paragraph, using canonical field ordering for source packages
+    pub fn set(&mut self, key: &str, value: &str) {
+        self.0.set_with_field_order(key, value, SOURCE_FIELD_ORDER);
     }
 
     /// Return the Vcs-Browser field
@@ -558,7 +563,7 @@ impl Source {
     /// Set the Vcs-Browser field
     pub fn set_vcs_browser(&mut self, url: Option<&str>) {
         if let Some(url) = url {
-            self.0.set("Vcs-Browser", url);
+            self.set("Vcs-Browser", url);
         } else {
             self.0.remove("Vcs-Browser");
         }
@@ -573,7 +578,7 @@ impl Source {
 
     /// Set the uploaders field
     pub fn set_uploaders(&mut self, uploaders: &[&str]) {
-        self.0.set(
+        self.set(
             "Uploaders",
             uploaders
                 .iter()
@@ -592,7 +597,7 @@ impl Source {
     /// Set the architecture field
     pub fn set_architecture(&mut self, arch: Option<&str>) {
         if let Some(arch) = arch {
-            self.0.set("Architecture", arch);
+            self.set("Architecture", arch);
         } else {
             self.0.remove("Architecture");
         }
@@ -611,7 +616,7 @@ impl Source {
 
     /// Set the Rules-Requires-Root field
     pub fn set_rules_requires_root(&mut self, requires_root: bool) {
-        self.0.set(
+        self.set(
             "Rules-Requires-Root",
             if requires_root { "yes" } else { "no" },
         );
@@ -624,7 +629,7 @@ impl Source {
 
     /// Set the Testsuite field
     pub fn set_testsuite(&mut self, testsuite: &str) {
-        self.0.set("Testsuite", testsuite);
+        self.set("Testsuite", testsuite);
     }
 
     /// Check if this source paragraph's range overlaps with the given range
@@ -761,6 +766,12 @@ impl Default for Binary {
     }
 }
 
+impl std::fmt::Display for Binary {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 impl Binary {
     /// Create a new binary package control file
     pub fn new() -> Self {
@@ -800,7 +811,7 @@ impl Binary {
 
     /// Set the name of the package
     pub fn set_name(&mut self, name: &str) {
-        self.0.set("Package", name);
+        self.set("Package", name);
     }
 
     /// The section of the package.
@@ -811,7 +822,7 @@ impl Binary {
     /// Set the section
     pub fn set_section(&mut self, section: Option<&str>) {
         if let Some(section) = section {
-            self.0.set("Section", section);
+            self.set("Section", section);
         } else {
             self.0.remove("Section");
         }
@@ -825,7 +836,7 @@ impl Binary {
     /// Set the priority of the package
     pub fn set_priority(&mut self, priority: Option<Priority>) {
         if let Some(priority) = priority {
-            self.0.set("Priority", priority.to_string().as_str());
+            self.set("Priority", priority.to_string().as_str());
         } else {
             self.0.remove("Priority");
         }
@@ -839,7 +850,7 @@ impl Binary {
     /// Set the architecture of the package
     pub fn set_architecture(&mut self, arch: Option<&str>) {
         if let Some(arch) = arch {
-            self.0.set("Architecture", arch);
+            self.set("Architecture", arch);
         } else {
             self.0.remove("Architecture");
         }
@@ -853,7 +864,7 @@ impl Binary {
     /// Set the Depends field
     pub fn set_depends(&mut self, depends: Option<&Relations>) {
         if let Some(depends) = depends {
-            self.0.set("Depends", depends.to_string().as_str());
+            self.set("Depends", depends.to_string().as_str());
         } else {
             self.0.remove("Depends");
         }
@@ -867,7 +878,7 @@ impl Binary {
     /// Set the Recommends field
     pub fn set_recommends(&mut self, recommends: Option<&Relations>) {
         if let Some(recommends) = recommends {
-            self.0.set("Recommends", recommends.to_string().as_str());
+            self.set("Recommends", recommends.to_string().as_str());
         } else {
             self.0.remove("Recommends");
         }
@@ -881,7 +892,7 @@ impl Binary {
     /// Set the Suggests field
     pub fn set_suggests(&mut self, suggests: Option<&Relations>) {
         if let Some(suggests) = suggests {
-            self.0.set("Suggests", suggests.to_string().as_str());
+            self.set("Suggests", suggests.to_string().as_str());
         } else {
             self.0.remove("Suggests");
         }
@@ -895,7 +906,7 @@ impl Binary {
     /// Set the Enhances field
     pub fn set_enhances(&mut self, enhances: Option<&Relations>) {
         if let Some(enhances) = enhances {
-            self.0.set("Enhances", enhances.to_string().as_str());
+            self.set("Enhances", enhances.to_string().as_str());
         } else {
             self.0.remove("Enhances");
         }
@@ -909,7 +920,7 @@ impl Binary {
     /// Set the Pre-Depends field
     pub fn set_pre_depends(&mut self, pre_depends: Option<&Relations>) {
         if let Some(pre_depends) = pre_depends {
-            self.0.set("Pre-Depends", pre_depends.to_string().as_str());
+            self.set("Pre-Depends", pre_depends.to_string().as_str());
         } else {
             self.0.remove("Pre-Depends");
         }
@@ -923,7 +934,7 @@ impl Binary {
     /// Set the Breaks field
     pub fn set_breaks(&mut self, breaks: Option<&Relations>) {
         if let Some(breaks) = breaks {
-            self.0.set("Breaks", breaks.to_string().as_str());
+            self.set("Breaks", breaks.to_string().as_str());
         } else {
             self.0.remove("Breaks");
         }
@@ -937,7 +948,7 @@ impl Binary {
     /// Set the Conflicts field
     pub fn set_conflicts(&mut self, conflicts: Option<&Relations>) {
         if let Some(conflicts) = conflicts {
-            self.0.set("Conflicts", conflicts.to_string().as_str());
+            self.set("Conflicts", conflicts.to_string().as_str());
         } else {
             self.0.remove("Conflicts");
         }
@@ -951,7 +962,7 @@ impl Binary {
     /// Set the Replaces field
     pub fn set_replaces(&mut self, replaces: Option<&Relations>) {
         if let Some(replaces) = replaces {
-            self.0.set("Replaces", replaces.to_string().as_str());
+            self.set("Replaces", replaces.to_string().as_str());
         } else {
             self.0.remove("Replaces");
         }
@@ -965,7 +976,7 @@ impl Binary {
     /// Set the Provides field
     pub fn set_provides(&mut self, provides: Option<&Relations>) {
         if let Some(provides) = provides {
-            self.0.set("Provides", provides.to_string().as_str());
+            self.set("Provides", provides.to_string().as_str());
         } else {
             self.0.remove("Provides");
         }
@@ -979,7 +990,7 @@ impl Binary {
     /// Set the Built-Using field
     pub fn set_built_using(&mut self, built_using: Option<&Relations>) {
         if let Some(built_using) = built_using {
-            self.0.set("Built-Using", built_using.to_string().as_str());
+            self.set("Built-Using", built_using.to_string().as_str());
         } else {
             self.0.remove("Built-Using");
         }
@@ -993,7 +1004,7 @@ impl Binary {
     /// Set the Multi-Arch field
     pub fn set_multi_arch(&mut self, multi_arch: Option<MultiArch>) {
         if let Some(multi_arch) = multi_arch {
-            self.0.set("Multi-Arch", multi_arch.to_string().as_str());
+            self.set("Multi-Arch", multi_arch.to_string().as_str());
         } else {
             self.0.remove("Multi-Arch");
         }
@@ -1007,7 +1018,7 @@ impl Binary {
     /// Set whether the package is essential
     pub fn set_essential(&mut self, essential: bool) {
         if essential {
-            self.0.set("Essential", "yes");
+            self.set("Essential", "yes");
         } else {
             self.0.remove("Essential");
         }
@@ -1021,7 +1032,7 @@ impl Binary {
     /// Set the binary package description
     pub fn set_description(&mut self, description: Option<&str>) {
         if let Some(description) = description {
-            self.0.set("Description", description);
+            self.set("Description", description);
         } else {
             self.0.remove("Description");
         }
@@ -1034,7 +1045,12 @@ impl Binary {
 
     /// Set the upstream homepage
     pub fn set_homepage(&mut self, url: &url::Url) {
-        self.0.set("Homepage", url.as_str());
+        self.set("Homepage", url.as_str());
+    }
+
+    /// Set a field in the binary paragraph, using canonical field ordering for binary packages
+    pub fn set(&mut self, key: &str, value: &str) {
+        self.0.set_with_field_order(key, value, BINARY_FIELD_ORDER);
     }
 
     /// Check if this binary paragraph's range overlaps with the given range
@@ -1071,6 +1087,183 @@ impl Binary {
 mod tests {
     use super::*;
     use crate::relations::VersionConstraint;
+
+    #[test]
+    fn test_source_set_field_ordering() {
+        let mut control = Control::new();
+        let mut source = control.add_source("mypackage");
+
+        // Add fields in random order
+        source.set("Homepage", "https://example.com");
+        source.set("Build-Depends", "debhelper");
+        source.set("Standards-Version", "4.5.0");
+        source.set("Maintainer", "Test <test@example.com>");
+
+        // Convert to string and check field order
+        let output = source.to_string();
+        let lines: Vec<&str> = output.lines().collect();
+
+        // Source should be first
+        assert!(lines[0].starts_with("Source:"));
+
+        // Find the positions of each field
+        let maintainer_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Maintainer:"))
+            .unwrap();
+        let build_depends_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Build-Depends:"))
+            .unwrap();
+        let standards_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Standards-Version:"))
+            .unwrap();
+        let homepage_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Homepage:"))
+            .unwrap();
+
+        // Check ordering according to SOURCE_FIELD_ORDER
+        assert!(maintainer_pos < build_depends_pos);
+        assert!(build_depends_pos < standards_pos);
+        assert!(standards_pos < homepage_pos);
+    }
+
+    #[test]
+    fn test_binary_set_field_ordering() {
+        let mut control = Control::new();
+        let mut binary = control.add_binary("mypackage");
+
+        // Add fields in random order
+        binary.set("Description", "A test package");
+        binary.set("Architecture", "amd64");
+        binary.set("Depends", "libc6");
+        binary.set("Section", "utils");
+
+        // Convert to string and check field order
+        let output = binary.to_string();
+        let lines: Vec<&str> = output.lines().collect();
+
+        // Package should be first
+        assert!(lines[0].starts_with("Package:"));
+
+        // Find the positions of each field
+        let arch_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Architecture:"))
+            .unwrap();
+        let section_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Section:"))
+            .unwrap();
+        let depends_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Depends:"))
+            .unwrap();
+        let desc_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Description:"))
+            .unwrap();
+
+        // Check ordering according to BINARY_FIELD_ORDER
+        assert!(arch_pos < section_pos);
+        assert!(section_pos < depends_pos);
+        assert!(depends_pos < desc_pos);
+    }
+
+    #[test]
+    fn test_source_specific_set_methods_use_field_ordering() {
+        let mut control = Control::new();
+        let mut source = control.add_source("mypackage");
+
+        // Use specific set_* methods in random order
+        source.set_homepage(&"https://example.com".parse().unwrap());
+        source.set_maintainer("Test <test@example.com>");
+        source.set_standards_version("4.5.0");
+        source.set_vcs_git("https://github.com/example/repo");
+
+        // Convert to string and check field order
+        let output = source.to_string();
+        let lines: Vec<&str> = output.lines().collect();
+
+        // Find the positions of each field
+        let source_pos = lines.iter().position(|l| l.starts_with("Source:")).unwrap();
+        let maintainer_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Maintainer:"))
+            .unwrap();
+        let standards_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Standards-Version:"))
+            .unwrap();
+        let vcs_git_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Vcs-Git:"))
+            .unwrap();
+        let homepage_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Homepage:"))
+            .unwrap();
+
+        // Check ordering according to SOURCE_FIELD_ORDER
+        assert!(source_pos < maintainer_pos);
+        assert!(maintainer_pos < standards_pos);
+        assert!(standards_pos < vcs_git_pos);
+        assert!(vcs_git_pos < homepage_pos);
+    }
+
+    #[test]
+    fn test_binary_specific_set_methods_use_field_ordering() {
+        let mut control = Control::new();
+        let mut binary = control.add_binary("mypackage");
+
+        // Use specific set_* methods in random order
+        binary.set_description(Some("A test package"));
+        binary.set_architecture(Some("amd64"));
+        let depends = "libc6".parse().unwrap();
+        binary.set_depends(Some(&depends));
+        binary.set_section(Some("utils"));
+        binary.set_priority(Some(Priority::Optional));
+
+        // Convert to string and check field order
+        let output = binary.to_string();
+        let lines: Vec<&str> = output.lines().collect();
+
+        // Find the positions of each field
+        let package_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Package:"))
+            .unwrap();
+        let arch_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Architecture:"))
+            .unwrap();
+        let section_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Section:"))
+            .unwrap();
+        let priority_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Priority:"))
+            .unwrap();
+        let depends_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Depends:"))
+            .unwrap();
+        let desc_pos = lines
+            .iter()
+            .position(|l| l.starts_with("Description:"))
+            .unwrap();
+
+        // Check ordering according to BINARY_FIELD_ORDER
+        assert!(package_pos < arch_pos);
+        assert!(arch_pos < section_pos);
+        assert!(section_pos < priority_pos);
+        assert!(priority_pos < depends_pos);
+        assert!(depends_pos < desc_pos);
+    }
+
     #[test]
     fn test_parse() {
         let control: Control = r#"Source: foo


### PR DESCRIPTION
Add set() methods to deb822-lossless and deb822-fast that insert new fields at the appropriate location based on canonical field ordering for Debian control files. This ensures that fields are placed in the conventional order when added to paragraphs.

- Define SOURCE_FIELD_ORDER and BINARY_FIELD_ORDER constants with the canonical field ordering for source and binary packages
- Implement set() and set_with_field_order() methods in both libraries that intelligently detect paragraph type and use appropriate ordering
- Add set() methods to Source and Binary types in debian-control that use the field-ordered set implementation
- Update all existing set_* methods in Source and Binary to use the new set() method, ensuring consistent field ordering
- Add Display implementation for Binary type

The implementation automatically detects whether a paragraph is a source or binary package based on the presence of "Source" or "Package" fields. Known fields are placed according to the canonical order, while unknown fields are sorted alphabetically among themselves.